### PR TITLE
Abstract token cache to interface to allow for custom implementations

### DIFF
--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -18,7 +18,7 @@ interface AccessTokenCache
      *
      * @return AccessToken|null
      */
-    public function getAccessToken(): ?AccessToken;
+    public function getAccessToken(string $identity): ?AccessToken;
 
     /**
      * Persist access token in cache
@@ -26,5 +26,5 @@ interface AccessTokenCache
      * @param AccessToken $accessToken
      * @return void
      */
-    public function persistAccessToken(AccessToken $accessToken): void;
+    public function persistAccessToken(string $identity, AccessToken $accessToken): void;
 }

--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -4,9 +4,27 @@ namespace Microsoft\Kiota\Authentication\Cache;
 
 use League\OAuth2\Client\Token\AccessToken;
 
+/**
+ * Interface AccessTokenCache
+ * @package Microsoft\Kiota\Authentication
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
 interface AccessTokenCache
 {
+    /**
+     * Return cached access token if available, else return null
+     *
+     * @return AccessToken|null
+     */
     public function getAccessToken(): ?AccessToken;
 
+    /**
+     * Persist access token in cache
+     *
+     * @param AccessToken $accessToken
+     * @return void
+     */
     public function persistAccessToken(AccessToken $accessToken): void;
 }

--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Microsoft\Kiota\Authentication\Cache;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+interface AccessTokenCache
+{
+    public function getAccessToken(): ?AccessToken;
+
+    public function persistAccessToken(AccessToken $accessToken): void;
+}

--- a/src/Cache/InMemoryAccessTokenCache.php
+++ b/src/Cache/InMemoryAccessTokenCache.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Microsoft\Kiota\Authentication\Cache;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+class InMemoryAccessTokenCache implements AccessTokenCache
+{
+    private ?AccessToken $accessToken = null;
+
+    public function getAccessToken(): ?AccessToken
+    {
+        return $this->accessToken;
+    }
+
+    public function persistAccessToken(AccessToken $accessToken): void
+    {
+        $this->accessToken = $accessToken;
+    }
+}

--- a/src/Cache/InMemoryAccessTokenCache.php
+++ b/src/Cache/InMemoryAccessTokenCache.php
@@ -16,15 +16,18 @@ use League\OAuth2\Client\Token\AccessToken;
  */
 class InMemoryAccessTokenCache implements AccessTokenCache
 {
-    private ?AccessToken $accessToken = null;
+    /**
+     * @var array<string, AccessToken>
+     */
+    private array $accessTokens = [];
 
-    public function getAccessToken(): ?AccessToken
+    public function getAccessToken(string $identity): ?AccessToken
     {
-        return $this->accessToken;
+        return $this->accessTokens[$identity] ?? null;
     }
 
-    public function persistAccessToken(AccessToken $accessToken): void
+    public function persistAccessToken(string $identity, AccessToken $accessToken): void
     {
-        $this->accessToken = $accessToken;
+        $this->accessTokens[$identity] = $accessToken;
     }
 }

--- a/src/Cache/InMemoryAccessTokenCache.php
+++ b/src/Cache/InMemoryAccessTokenCache.php
@@ -4,6 +4,16 @@ namespace Microsoft\Kiota\Authentication\Cache;
 
 use League\OAuth2\Client\Token\AccessToken;
 
+/**
+ * Class InMemoryAccessTokenCache
+ *
+ * In memory cache for access token
+ *
+ * @package Microsoft\Kiota\Authentication
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
 class InMemoryAccessTokenCache implements AccessTokenCache
 {
     private ?AccessToken $accessToken = null;

--- a/src/Oauth/BaseCertificateContext.php
+++ b/src/Oauth/BaseCertificateContext.php
@@ -128,4 +128,9 @@ class BaseCertificateContext implements TokenRequestContext
             'x5t' => JWT::urlsafeB64Encode( hex2bin($this->certificateFingerprint))
         ]);
     }
+
+    public function getIdentity(): string
+    {
+        return $this->clientId;
+    }
 }

--- a/src/Oauth/BaseSecretContext.php
+++ b/src/Oauth/BaseSecretContext.php
@@ -78,4 +78,9 @@ class BaseSecretContext implements TokenRequestContext
     {
         return $this->tenantId;
     }
+
+    public function getIdentity(): string
+    {
+        return $this->getTenantId();
+    }
 }

--- a/src/Oauth/TokenRequestContext.php
+++ b/src/Oauth/TokenRequestContext.php
@@ -42,4 +42,10 @@ interface TokenRequestContext
      * @return string
      */
     public function getTenantId(): string;
+
+    /**
+     * Return the identity of the user, this is used to cache the access token
+     * @return string
+     */
+    public function getIdentity(): string;
 }

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -18,6 +18,8 @@ use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessToken;
 use Microsoft\Kiota\Abstractions\Authentication\AccessTokenProvider;
 use Microsoft\Kiota\Abstractions\Authentication\AllowedHostsValidator;
+use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
+use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
 use Microsoft\Kiota\Authentication\Oauth\OnBehalfOfGrant;
 use Microsoft\Kiota\Authentication\Oauth\TokenRequestContext;
 
@@ -42,14 +44,16 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
      * @var array<string, string>
      */
     private array $scopes;
-    /**
-     * @var AccessToken|null Token object to re-use before expiry
-     */
-    private ?AccessToken $cachedToken = null;
+
     /**
      * @var GenericProvider OAuth 2.0 provider from PHP League library
      */
     private GenericProvider $oauthProvider;
+
+    /**
+     * @var AccessTokenCache Cache to store access token
+     */
+    private AccessTokenCache $accessTokenCache;
 
     /**
      * Creates a new instance
@@ -57,12 +61,15 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
      * @param array $scopes
      * @param array $allowedHosts
      */
-    public function __construct(TokenRequestContext $tokenRequestContext, array $scopes = [], array $allowedHosts = [])
+    public function __construct(TokenRequestContext $tokenRequestContext, array $scopes = [], array $allowedHosts = [], ?AccessTokenCache $accessTokenCache = null)
     {
         $this->tokenRequestContext = $tokenRequestContext;
         $this->scopes = $scopes;
         $this->allowedHostsValidator = new AllowedHostsValidator();
         $this->allowedHostsValidator->setAllowedHosts($allowedHosts);
+
+        $this->accessTokenCache = $accessTokenCache === null ? new InMemoryAccessTokenCache() : $accessTokenCache;
+
         $this->initOauthProvider();
     }
 
@@ -78,24 +85,28 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
         if ($scheme !== 'https' || !$this->getAllowedHostsValidator()->isUrlHostValid($url)) {
             return new FulfilledPromise(null);
         }
+
         $this->scopes = $this->scopes ?: ["{$scheme}://{$host}/.default"];
         try {
             $params = array_merge($this->tokenRequestContext->getParams(), ['scope' => implode(' ', $this->scopes)]);
-            if ($this->cachedToken) {
-                if ($this->cachedToken->getExpires() && $this->cachedToken->hasExpired()) {
-                    if ($this->cachedToken->getRefreshToken()) {
+            $accessToken = $this->accessTokenCache->getAccessToken();
+            if ($accessToken) {
+                if ($accessToken->getExpires() && $accessToken->hasExpired()) {
+                    if ($accessToken->getRefreshToken()) {
                         // @phpstan-ignore-next-line
-                        $this->cachedToken = $this->oauthProvider->getAccessToken('refresh_token', $this->tokenRequestContext->getRefreshTokenParams($this->cachedToken->getRefreshToken()));
+                        $accessToken = $this->oauthProvider->getAccessToken('refresh_token', $this->tokenRequestContext->getRefreshTokenParams($accessToken->getRefreshToken()));
                     } else {
                         // @phpstan-ignore-next-line
-                        $this->cachedToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
+                        $accessToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
                     }
+                    $this->accessTokenCache->persistAccessToken($accessToken);
                 }
-                return new FulfilledPromise($this->cachedToken->getToken());
+                return new FulfilledPromise($accessToken->getToken());
             }
             // @phpstan-ignore-next-line
-            $this->cachedToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
-            return new FulfilledPromise($this->cachedToken->getToken());
+            $accessToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
+            $this->accessTokenCache->persistAccessToken($accessToken);
+            return new FulfilledPromise($accessToken->getToken());
         } catch (\Exception $ex) {
             return new RejectedPromise($ex);
         }

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -91,17 +91,14 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
             if ($accessToken) {
                 if ($accessToken->getExpires() && $accessToken->hasExpired()) {
                     if ($accessToken->getRefreshToken()) {
-                        // @phpstan-ignore-next-line
                         $accessToken = $this->oauthProvider->getAccessToken('refresh_token', $this->tokenRequestContext->getRefreshTokenParams($accessToken->getRefreshToken()));
                     } else {
-                        // @phpstan-ignore-next-line
                         $accessToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
                     }
                     $this->accessTokenCache->persistAccessToken($accessToken);
                 }
                 return new FulfilledPromise($accessToken->getToken());
             }
-            // @phpstan-ignore-next-line
             $accessToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
             $this->accessTokenCache->persistAccessToken($accessToken);
             return new FulfilledPromise($accessToken->getToken());

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -87,7 +87,7 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
         $this->scopes = $this->scopes ?: ["{$scheme}://{$host}/.default"];
         try {
             $params = array_merge($this->tokenRequestContext->getParams(), ['scope' => implode(' ', $this->scopes)]);
-            $accessToken = $this->accessTokenCache->getAccessToken();
+            $accessToken = $this->accessTokenCache->getAccessToken($this->tokenRequestContext->getIdentity());
             if ($accessToken) {
                 if ($accessToken->getExpires() && $accessToken->hasExpired()) {
                     if ($accessToken->getRefreshToken()) {
@@ -95,12 +95,12 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
                     } else {
                         $accessToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
                     }
-                    $this->accessTokenCache->persistAccessToken($accessToken);
+                    $this->accessTokenCache->persistAccessToken($this->tokenRequestContext->getIdentity(), $accessToken);
                 }
                 return new FulfilledPromise($accessToken->getToken());
             }
             $accessToken = $this->oauthProvider->getAccessToken($this->tokenRequestContext->getGrantType(), $params);
-            $this->accessTokenCache->persistAccessToken($accessToken);
+            $this->accessTokenCache->persistAccessToken($this->tokenRequestContext->getIdentity(), $accessToken);
             return new FulfilledPromise($accessToken->getToken());
         } catch (\Exception $ex) {
             return new RejectedPromise($ex);

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -15,7 +15,6 @@ use Http\Promise\RejectedPromise;
 use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\GenericProvider;
-use League\OAuth2\Client\Token\AccessToken;
 use Microsoft\Kiota\Abstractions\Authentication\AccessTokenProvider;
 use Microsoft\Kiota\Abstractions\Authentication\AllowedHostsValidator;
 use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
@@ -60,6 +59,7 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
      * @param TokenRequestContext $tokenRequestContext
      * @param array $scopes
      * @param array $allowedHosts
+     * @param AccessTokenCache|null $accessTokenCache
      */
     public function __construct(TokenRequestContext $tokenRequestContext, array $scopes = [], array $allowedHosts = [], ?AccessTokenCache $accessTokenCache = null)
     {

--- a/tests/PhpLeagueAccessTokenProviderTest.php
+++ b/tests/PhpLeagueAccessTokenProviderTest.php
@@ -89,7 +89,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
     {
         $oauthContexts = $this->getOauthContexts();
         foreach ($oauthContexts as $tokenRequestContext) {
-            $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], $stubTokenCache = new StubAccessTokenCache());
+            $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], null, $stubTokenCache = new StubAccessTokenCache());
             $stubTokenCache->accessToken = new AccessToken(['access_token' => 'persisted_token', 'expires' => time() + 5]);
             $mockResponses = [
                 new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
@@ -103,7 +103,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
     {
         $oauthContexts = $this->getOauthContexts();
         foreach ($oauthContexts as $tokenRequestContext) {
-            $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], $stubTokenCache = new StubAccessTokenCache());
+            $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], null, $stubTokenCache = new StubAccessTokenCache());
             $mockResponses = [
                 new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
             ];

--- a/tests/Stub/StubAccessTokenCache.php
+++ b/tests/Stub/StubAccessTokenCache.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Microsoft\Kiota\Authentication\Test\Stub;
+
+use League\OAuth2\Client\Token\AccessToken;
+use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
+
+class StubAccessTokenCache implements AccessTokenCache
+{
+    public ?AccessToken $accessToken = null;
+
+    public function getAccessToken(): ?AccessToken
+    {
+        return $this->accessToken;
+    }
+
+    public function persistAccessToken(AccessToken $accessToken): void
+    {
+        $this->accessToken = $accessToken;
+    }
+}

--- a/tests/Stub/StubAccessTokenCache.php
+++ b/tests/Stub/StubAccessTokenCache.php
@@ -7,15 +7,18 @@ use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
 
 class StubAccessTokenCache implements AccessTokenCache
 {
-    public ?AccessToken $accessToken = null;
+    /**
+     * @var array<string, AccessToken>
+     */
+    public array $accessTokens = [];
 
-    public function getAccessToken(): ?AccessToken
+    public function getAccessToken(string $identity): ?AccessToken
     {
-        return $this->accessToken;
+        return $this->accessTokens[$identity] ?? null;
     }
 
-    public function persistAccessToken(AccessToken $accessToken): void
+    public function persistAccessToken(string $identity, AccessToken $accessToken): void
     {
-        $this->accessToken = $accessToken;
+        $this->accessTokens[$identity] = $accessToken;
     }
 }


### PR DESCRIPTION
Abstracts caching of tokens to allow for custom implementations (for example, storing tokens between requests).

The constructor of `PhpLeagueAccessTokenProvider` falls back to a default "inMemory" cache to enable backwards compatibility. 