### PR TITLE
Abstract token caching

### DIFF
--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -18,7 +18,7 @@ interface AccessTokenCache
      *
      * @return AccessToken|null
      */
-    public function getAccessToken(): ?AccessToken;
+    public function getAccessToken(string $identity): ?AccessToken;
 
     /**
      * Persist access token in cache
@@ -26,5 +26,5 @@ interface AccessTokenCache
      * @param AccessToken $accessToken
      * @return void
      */
-    public function persistAccessToken(AccessToken $accessToken): void;
+    public function persistAccessToken(string $identity, AccessToken $accessToken): void;
 }

--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -16,6 +16,7 @@ interface AccessTokenCache
     /**
      * Return cached access token if available, else return null
      *
+     * @param string $identity
      * @return AccessToken|null
      */
     public function getAccessToken(string $identity): ?AccessToken;
@@ -23,6 +24,7 @@ interface AccessTokenCache
     /**
      * Persist access token in cache
      *
+     * @param string $identity
      * @param AccessToken $accessToken
      * @return void
      */

--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -4,9 +4,27 @@ namespace Microsoft\Kiota\Authentication\Cache;
 
 use League\OAuth2\Client\Token\AccessToken;
 
+/**
+ * Interface AccessTokenCache
+ * @package Microsoft\Kiota\Authentication
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
 interface AccessTokenCache
 {
+    /**
+     * Return cached access token if available, else return null
+     *
+     * @return AccessToken|null
+     */
     public function getAccessToken(): ?AccessToken;
 
+    /**
+     * Persist access token in cache
+     *
+     * @param AccessToken $accessToken
+     * @return void
+     */
     public function persistAccessToken(AccessToken $accessToken): void;
 }

--- a/src/Cache/AccessTokenCache.php
+++ b/src/Cache/AccessTokenCache.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Microsoft\Kiota\Authentication\Cache;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+interface AccessTokenCache
+{
+    public function getAccessToken(): ?AccessToken;
+
+    public function persistAccessToken(AccessToken $accessToken): void;
+}

--- a/src/Cache/InMemoryAccessTokenCache.php
+++ b/src/Cache/InMemoryAccessTokenCache.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Microsoft\Kiota\Authentication\Cache;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+class InMemoryAccessTokenCache implements AccessTokenCache
+{
+    private ?AccessToken $accessToken = null;
+
+    public function getAccessToken(): ?AccessToken
+    {
+        return $this->accessToken;
+    }
+
+    public function persistAccessToken(AccessToken $accessToken): void
+    {
+        $this->accessToken = $accessToken;
+    }
+}

--- a/src/Cache/InMemoryAccessTokenCache.php
+++ b/src/Cache/InMemoryAccessTokenCache.php
@@ -16,15 +16,18 @@ use League\OAuth2\Client\Token\AccessToken;
  */
 class InMemoryAccessTokenCache implements AccessTokenCache
 {
-    private ?AccessToken $accessToken = null;
+    /**
+     * @var array<string, AccessToken>
+     */
+    private array $accessTokens = [];
 
-    public function getAccessToken(): ?AccessToken
+    public function getAccessToken(string $identity): ?AccessToken
     {
-        return $this->accessToken;
+        return $this->accessTokens[$identity] ?? null;
     }
 
-    public function persistAccessToken(AccessToken $accessToken): void
+    public function persistAccessToken(string $identity, AccessToken $accessToken): void
     {
-        $this->accessToken = $accessToken;
+        $this->accessTokens[$identity] = $accessToken;
     }
 }

--- a/src/Cache/InMemoryAccessTokenCache.php
+++ b/src/Cache/InMemoryAccessTokenCache.php
@@ -4,6 +4,16 @@ namespace Microsoft\Kiota\Authentication\Cache;
 
 use League\OAuth2\Client\Token\AccessToken;
 
+/**
+ * Class InMemoryAccessTokenCache
+ *
+ * In memory cache for access token
+ *
+ * @package Microsoft\Kiota\Authentication
+ * @copyright 2022 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
 class InMemoryAccessTokenCache implements AccessTokenCache
 {
     private ?AccessToken $accessToken = null;

--- a/src/Oauth/ApplicationPermissionTrait.php
+++ b/src/Oauth/ApplicationPermissionTrait.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Authentication\Oauth;
+
+
+use League\OAuth2\Client\Token\AccessToken;
+
+trait ApplicationPermissionTrait
+{
+    use CAEConfigurationTrait;
+
+    /**
+     * @var string|null
+     */
+    private ?string $cacheKey = null;
+
+    /**
+     * @return string
+     */
+    abstract public function getClientId(): string;
+
+    /**
+     * @return string
+     */
+    abstract public function getTenantId(): string;
+
+    /**
+     * Set the identity of the user/application. This is used as the unique cache key
+     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For application permissions, they key is {tenantId}-{clientId}
+     * @param AccessToken|null $accessToken
+     * @return void
+     */
+    public function setCacheKey(?AccessToken $accessToken = null): void
+    {
+        $this->cacheKey = "{$this->getTenantId()}-{$this->getClientId()}";
+    }
+
+    /**
+     * Return the identity of the user/application. This is used as the unique cache key
+     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For application permissions, they key is {tenantId}-{clientId}
+     * @return string|null
+     */
+    public function getCacheKey(): ?string
+    {
+        return $this->cacheKey;
+    }
+}

--- a/src/Oauth/AuthorizationCodeCertificateContext.php
+++ b/src/Oauth/AuthorizationCodeCertificateContext.php
@@ -18,8 +18,10 @@ namespace Microsoft\Kiota\Authentication\Oauth;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class AuthorizationCodeCertificateContext extends BaseCertificateContext
+class AuthorizationCodeCertificateContext extends BaseCertificateContext implements TokenRequestContext
 {
+    use DelegatedPermissionTrait;
+
     private string $authCode;
     private string $redirectUri;
     private array $additionalParams;

--- a/src/Oauth/AuthorizationCodeContext.php
+++ b/src/Oauth/AuthorizationCodeContext.php
@@ -18,8 +18,10 @@ namespace Microsoft\Kiota\Authentication\Oauth;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class AuthorizationCodeContext extends BaseSecretContext
+class AuthorizationCodeContext extends BaseSecretContext implements TokenRequestContext
 {
+    use DelegatedPermissionTrait;
+
     /**
      * @var string Code from the authorization step
      */

--- a/src/Oauth/BaseCertificateContext.php
+++ b/src/Oauth/BaseCertificateContext.php
@@ -12,7 +12,14 @@ namespace Microsoft\Kiota\Authentication\Oauth;
 use Firebase\JWT\JWT;
 use Ramsey\Uuid\Uuid;
 
-class BaseCertificateContext extends TokenRequestContext
+/**
+ * Class BaseCertificateContext
+ * @package Microsoft\Kiota\Authentication\Oauth
+ * @copyright 2023 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://learn.microsoft.com/en-us/openapi/kiota/
+ */
+class BaseCertificateContext
 {
     /**
      * @var string Tenant Id
@@ -67,7 +74,7 @@ class BaseCertificateContext extends TokenRequestContext
     }
 
     /**
-     * @inheritDoc
+     * @return array<string, string>
      */
     public function getParams(): array
     {
@@ -79,7 +86,8 @@ class BaseCertificateContext extends TokenRequestContext
     }
 
     /**
-     * @inheritDoc
+     * @param string $refreshToken
+     * @return array<string, string>
      */
     public function getRefreshTokenParams(string $refreshToken): array
     {
@@ -93,19 +101,19 @@ class BaseCertificateContext extends TokenRequestContext
     }
 
     /**
-     * @inheritDoc
-     */
-    public function getGrantType(): string
-    {
-        return '';
-    }
-
-    /**
-     * @inheritDoc
+     * @return string
      */
     public function getTenantId(): string
     {
         return $this->tenantId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientId(): string
+    {
+        return $this->clientId;
     }
 
     /**
@@ -127,10 +135,5 @@ class BaseCertificateContext extends TokenRequestContext
         return JWT::encode($claims, $this->privateKey, 'RS256', null, [
             'x5t' => JWT::urlsafeB64Encode( hex2bin($this->certificateFingerprint))
         ]);
-    }
-
-    public function getIdentity(): string
-    {
-        return $this->clientId;
     }
 }

--- a/src/Oauth/BaseCertificateContext.php
+++ b/src/Oauth/BaseCertificateContext.php
@@ -128,4 +128,9 @@ class BaseCertificateContext extends TokenRequestContext
             'x5t' => JWT::urlsafeB64Encode( hex2bin($this->certificateFingerprint))
         ]);
     }
+
+    public function getIdentity(): string
+    {
+        return $this->clientId;
+    }
 }

--- a/src/Oauth/BaseSecretContext.php
+++ b/src/Oauth/BaseSecretContext.php
@@ -80,4 +80,9 @@ class BaseSecretContext extends TokenRequestContext
     {
         return $this->tenantId;
     }
+
+    public function getIdentity(): string
+    {
+        return $this->getTenantId();
+    }
 }

--- a/src/Oauth/BaseSecretContext.php
+++ b/src/Oauth/BaseSecretContext.php
@@ -8,8 +8,6 @@
 
 namespace Microsoft\Kiota\Authentication\Oauth;
 
-use League\OAuth2\Client\Provider\AbstractProvider;
-
 /**
  * Class BaseSecretContext
  *
@@ -20,7 +18,7 @@ use League\OAuth2\Client\Provider\AbstractProvider;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class BaseSecretContext extends TokenRequestContext
+class BaseSecretContext
 {
     /**
      * @var string Tenant Id
@@ -51,7 +49,7 @@ class BaseSecretContext extends TokenRequestContext
     }
 
     /**
-     * @inheritDoc
+     * @return array<string, string>
      */
     public function getParams(): array
     {
@@ -61,6 +59,10 @@ class BaseSecretContext extends TokenRequestContext
         ];
     }
 
+    /**
+     * @param string $refreshToken
+     * @return array<string, string>
+     */
     public function getRefreshTokenParams(string $refreshToken): array
     {
         return [
@@ -71,18 +73,19 @@ class BaseSecretContext extends TokenRequestContext
         ];
     }
 
-    public function getGrantType(): string
-    {
-        return '';
-    }
-
+    /**
+     * @return string
+     */
     public function getTenantId(): string
     {
         return $this->tenantId;
     }
 
-    public function getIdentity(): string
+    /**
+     * @return string
+     */
+    public function getClientId(): string
     {
-        return $this->getTenantId();
+        return $this->clientId;
     }
 }

--- a/src/Oauth/CAEConfigurationTrait.php
+++ b/src/Oauth/CAEConfigurationTrait.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Authentication\Oauth;
+
+use Http\Promise\Promise;
+
+trait CAEConfigurationTrait
+{
+    /**
+     * Should return Promise that resolves with a new TokenRequestContext object to be used for a new token request
+     * @var null|callable(string $claims): Promise
+     */
+    private $caeRedirectCallback = null;
+
+    /**
+     * Whether this client should add claims to inform API that it can handle claims challenges.
+     * Disabled by default since different Identity Providers can be used with this lib. Not only Azure which understands
+     * the cp1 claim
+     * https://learn.microsoft.com/en-us/azure/active-directory/develop/claims-challenge?tabs=dotnet
+     * @var bool
+     */
+    private bool $caeEnabled = false;
+
+    /**
+     * Whether the client should be enabled for Continuous Access Evaluation
+     * https://learn.microsoft.com/en-us/azure/active-directory/conditional-access/concept-continuous-access-evaluation
+     * Currently only works with Microsoft Identity
+     * @return bool
+     */
+    public function isCAEEnabled(): bool
+    {
+        return $this->caeEnabled;
+    }
+
+    /**
+     * Returns a callback that can be called to redirect the logged-in user to the Microsoft Identity login page
+     * when this lib is unable to refresh the token using CAE claims.
+     * If this callback returns a Promise that resolves to a new token request context with the new authentication
+     * code/assertion then a new token is requested.
+     * @return null|callable(string $claims): Promise
+     */
+    public function getCAERedirectCallback(): ?callable
+    {
+        return $this->caeRedirectCallback;
+    }
+
+    /**
+     * @param bool $caeEnabled
+     */
+    public function setCAEEnabled(bool $caeEnabled): void
+    {
+        $this->caeEnabled = $caeEnabled;
+    }
+
+    /**
+     * @param null|callable(string $claims): Promise $callback
+     */
+    public function setCAERedirectCallback(?callable $callback = null): void
+    {
+        $this->caeRedirectCallback = $callback;
+    }
+}

--- a/src/Oauth/ClientCredentialCertificateContext.php
+++ b/src/Oauth/ClientCredentialCertificateContext.php
@@ -18,8 +18,10 @@ namespace Microsoft\Kiota\Authentication\Oauth;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class ClientCredentialCertificateContext extends BaseCertificateContext
+class ClientCredentialCertificateContext extends BaseCertificateContext implements TokenRequestContext
 {
+    use ApplicationPermissionTrait;
+
     private array $additionalParams;
 
     /**

--- a/src/Oauth/ClientCredentialContext.php
+++ b/src/Oauth/ClientCredentialContext.php
@@ -18,8 +18,10 @@ namespace Microsoft\Kiota\Authentication\Oauth;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class ClientCredentialContext extends BaseSecretContext
+class ClientCredentialContext extends BaseSecretContext implements TokenRequestContext
 {
+    use ApplicationPermissionTrait;
+
     /**
      * @var array<string, string> Key-value pairs of additional OAuth 2.0 parameters
      */

--- a/src/Oauth/DelegatedPermissionTrait.php
+++ b/src/Oauth/DelegatedPermissionTrait.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Authentication\Oauth;
+
+
+use League\OAuth2\Client\Token\AccessToken;
+
+
+trait DelegatedPermissionTrait
+{
+    use CAEConfigurationTrait;
+
+    /**
+     * @var string|null
+     */
+    private ?string $cacheKey = null;
+
+    /**
+     * @return string
+     */
+    abstract public function getClientId(): string;
+
+    /**
+     * @return string
+     */
+    abstract public function getTenantId(): string;
+
+    /**
+     * Set the identity of the user/application. This is used as the unique cache key
+     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For application permissions, they key is {tenantId}-{clientId}
+     * @param AccessToken|null $accessToken
+     * @return void
+     */
+    public function setCacheKey(?AccessToken $accessToken = null): void
+    {
+        if ($accessToken && $accessToken->getToken()) {
+            $tokenParts = explode('.', $accessToken->getToken());
+            if (count($tokenParts) == 3) {
+                $payload = json_decode(base64_decode($tokenParts[1]), true);
+                $subject = $payload['sub'] ?? false;
+                $this->cacheKey = ($subject) ? "{$this->getTenantId()}-{$this->getClientId()}-{$subject}" : null;
+            }
+        }
+    }
+
+    /**
+     * Return the identity of the user/application. This is used as the unique cache key
+     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For application permissions, they key is {tenantId}-{clientId}
+     * @return string|null
+     */
+    public function getCacheKey(): ?string
+    {
+        return $this->cacheKey;
+    }
+}

--- a/src/Oauth/OnBehalfOfCertificateContext.php
+++ b/src/Oauth/OnBehalfOfCertificateContext.php
@@ -18,8 +18,10 @@ namespace Microsoft\Kiota\Authentication\Oauth;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class OnBehalfOfCertificateContext extends BaseCertificateContext
+class OnBehalfOfCertificateContext extends BaseCertificateContext implements TokenRequestContext
 {
+    use DelegatedPermissionTrait;
+
     /**
      * @var string
      */

--- a/src/Oauth/OnBehalfOfContext.php
+++ b/src/Oauth/OnBehalfOfContext.php
@@ -18,8 +18,10 @@ namespace Microsoft\Kiota\Authentication\Oauth;
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-class OnBehalfOfContext extends BaseSecretContext
+class OnBehalfOfContext extends BaseSecretContext implements TokenRequestContext
 {
+    use DelegatedPermissionTrait;
+
     /**
      * @var string
      */

--- a/src/Oauth/TokenRequestContext.php
+++ b/src/Oauth/TokenRequestContext.php
@@ -8,7 +8,6 @@
 
 namespace Microsoft\Kiota\Authentication\Oauth;
 
-use League\OAuth2\Client\Provider\AbstractProvider;
 use Http\Promise\Promise;
 
 /**
@@ -60,6 +59,12 @@ abstract class TokenRequestContext
      * @return string
      */
     abstract public function getTenantId(): string;
+
+    /**
+     * Return the identity of the user, this is used to cache the access token
+     * @return string
+     */
+    abstract public function getIdentity(): string;
 
     /**
      * Whether the client should be enabled for Continuous Access Evaluation

--- a/src/Oauth/TokenRequestContext.php
+++ b/src/Oauth/TokenRequestContext.php
@@ -8,38 +8,24 @@
 
 namespace Microsoft\Kiota\Authentication\Oauth;
 
+use League\OAuth2\Client\Token\AccessToken;
 use Http\Promise\Promise;
 
 /**
- * Class TokenRequestContext
+ * Interface TokenRequestContext
  * @package Microsoft\Kiota\Authentication
  * @copyright 2022 Microsoft Corporation
  * @license https://opensource.org/licenses/MIT MIT License
  * @link https://developer.microsoft.com/graph
  */
-abstract class TokenRequestContext
+interface TokenRequestContext
 {
-    /**
-     * Should return Promise that resolves with a new TokenRequestContext object to be used for a new token request
-     * @var null|callable(string $claims): Promise
-     */
-    private $caeRedirectCallback = null;
-
-    /**
-     * Whether this client should add claims to inform API that it can handle claims challenges.
-     * Disabled by default since different Identity Providers can be used with this lib. Not only Azure which
-     * understands the cp1 claim
-     * https://learn.microsoft.com/en-us/azure/active-directory/develop/claims-challenge?tabs=dotnet
-     * @var bool
-     */
-    private bool $caeEnabled = false;
-
     /**
      * Return dictionary with OAuth 2.0 request parameters to be passed to PHP League's OAuth provider
      *
      * @return array<string, string>
      */
-    abstract public function getParams(): array;
+    public function getParams(): array;
 
     /**
      * Returns subset of parameters to be used for refresh_token requests
@@ -47,24 +33,36 @@ abstract class TokenRequestContext
      * @param string $refreshToken refresh token in currently cached token
      * @return array<string, string>
      */
-    abstract public function getRefreshTokenParams(string $refreshToken): array;
+    public function getRefreshTokenParams(string $refreshToken): array;
 
     /**
      * @return string Grant type
      */
-    abstract public function getGrantType(): string;
+    public function getGrantType(): string;
 
     /**
      * Return the tenantId
      * @return string
      */
-    abstract public function getTenantId(): string;
+    public function getTenantId(): string;
 
     /**
-     * Return the identity of the user, this is used to cache the access token
-     * @return string
+     * Set the identity of the user/application. This is used as the unique cache key
+     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For application permissions, they key is {tenantId}-{clientId}
+     * @param AccessToken|null $accessToken
+     * @return void
      */
-    abstract public function getIdentity(): string;
+    public function setCacheKey(?AccessToken $accessToken = null): void;
+
+    /**
+     * Return the identity of the user/application. This is used as the unique cache key
+     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For application permissions, they key is {tenantId}-{clientId}
+     *
+     * @return string|null
+     */
+    public function getCacheKey(): ?string;
 
     /**
      * Whether the client should be enabled for Continuous Access Evaluation
@@ -72,36 +70,15 @@ abstract class TokenRequestContext
      * Currently only works with Microsoft Identity
      * @return bool
      */
-    public function isCAEEnabled(): bool
-    {
-        return $this->caeEnabled;
-    }
+    public function isCAEEnabled(): bool;
 
     /**
      * Returns a callback that can be called to redirect the logged-in user to the Microsoft Identity login page
      * when this lib is unable to refresh the token using CAE claims.
      * If this callback returns a Promise that resolves to a new token request context with the new authentication
      * code/assertion then a new token is requested.
+     *
      * @return null|callable(string $claims): Promise
      */
-    public function getCAERedirectCallback(): ?callable
-    {
-        return $this->caeRedirectCallback;
-    }
-
-    /**
-     * @param bool $caeEnabled
-     */
-    public function setCAEEnabled(bool $caeEnabled): void
-    {
-        $this->caeEnabled = $caeEnabled;
-    }
-
-    /**
-     * @param null|callable(string $claims): Promise $callback
-     */
-    public function setCAERedirectCallback(?callable $callback = null): void
-    {
-        $this->caeRedirectCallback = $callback;
-    }
+    public function getCAERedirectCallback(): ?callable;
 }

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -21,7 +21,6 @@ use Microsoft\Kiota\Authentication\Oauth\ContinuousAccessEvaluationException;
 use Microsoft\Kiota\Authentication\Oauth\ProviderFactory;
 use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
 use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
-use Microsoft\Kiota\Authentication\Oauth\OnBehalfOfGrant;
 use Microsoft\Kiota\Authentication\Oauth\TokenRequestContext;
 
 /**

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -108,7 +108,7 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
                 }
             }
 
-            if (!$this->tokenRequestContext->getCacheKey()) {
+            if ($this->tokenRequestContext->getCacheKey()) {
                 $cachedToken = $this->accessTokenCache->getAccessToken($this->tokenRequestContext->getCacheKey());
                 if ($cachedToken) {
                     if ($cachedToken->getExpires() && !$cachedToken->hasExpired()) {

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -19,6 +19,9 @@ use Microsoft\Kiota\Abstractions\Authentication\AccessTokenProvider;
 use Microsoft\Kiota\Abstractions\Authentication\AllowedHostsValidator;
 use Microsoft\Kiota\Authentication\Oauth\ContinuousAccessEvaluationException;
 use Microsoft\Kiota\Authentication\Oauth\ProviderFactory;
+use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
+use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
+use Microsoft\Kiota\Authentication\Oauth\OnBehalfOfGrant;
 use Microsoft\Kiota\Authentication\Oauth\TokenRequestContext;
 
 /**
@@ -44,29 +47,40 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
      * @var array<string, string>
      */
     private array $scopes;
-    /**
-     * @var AccessToken|null Token object to re-use before expiry
-     */
-    private ?AccessToken $cachedToken = null;
+
     /**
      * @var AbstractProvider OAuth 2.0 provider from PHP League library
      */
     private AbstractProvider $oauthProvider;
 
     /**
+     * @var AccessTokenCache Cache to store access token
+     */
+    private AccessTokenCache $accessTokenCache;
+
+    /**
      * Creates a new instance
      * @param TokenRequestContext $tokenRequestContext
      * @param array $scopes
      * @param array $allowedHosts
-     * @param AbstractProvider|null $oauthProvider
+     * @param AbstractProvider|null $oauthProvider when null, defaults to a Microsoft Identity Authentication Provider
+     * @param AccessTokenCache|null $accessTokenCache defaults to an in-memory cache
      */
-    public function __construct(TokenRequestContext $tokenRequestContext, array $scopes = [], array $allowedHosts = [], ?AbstractProvider $oauthProvider = null)
+    public function __construct(
+        TokenRequestContext $tokenRequestContext,
+        array $scopes = [],
+        array $allowedHosts = [],
+        ?AbstractProvider $oauthProvider = null,
+        ?AccessTokenCache $accessTokenCache = null
+    )
     {
         $this->tokenRequestContext = $tokenRequestContext;
         $this->scopes = $scopes;
         $this->allowedHostsValidator = new AllowedHostsValidator();
         $this->allowedHostsValidator->setAllowedHosts($allowedHosts);
         $this->oauthProvider = $oauthProvider ?? ProviderFactory::create($tokenRequestContext);
+        $this->accessTokenCache = $accessTokenCache === null ? new InMemoryAccessTokenCache() : $accessTokenCache;
+
     }
 
     /**
@@ -81,25 +95,30 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
         if ($scheme !== 'https' || !$this->getAllowedHostsValidator()->isUrlHostValid($url)) {
             return new FulfilledPromise(null);
         }
+
         $this->scopes = $this->scopes ?: ["{$scheme}://{$host}/.default"];
         try {
             $params = array_merge($this->tokenRequestContext->getParams(), ['scope' => implode(' ', $this->scopes)]);
             if ($additionalAuthenticationContext['claims'] ?? false) {
                 $claims = base64_decode($additionalAuthenticationContext['claims']);
-                $this->cachedToken = $this->tryCAETokenRefresh($params, $claims);
-                return new FulfilledPromise($this->cachedToken->getToken());
+                $token = $this->tryCAETokenRefresh($params, $claims);
+                $this->accessTokenCache->persistAccessToken($token);
+                return new FulfilledPromise($token->getToken());
             }
-            if ($this->cachedToken) {
-                if ($this->cachedToken->getExpires() && !$this->cachedToken->hasExpired()) {
-                    return new FulfilledPromise($this->cachedToken->getToken());
+            $cachedToken = $this->accessTokenCache->getAccessToken();
+            if ($cachedToken) {
+                if ($cachedToken->getExpires() && !$cachedToken->hasExpired()) {
+                    return new FulfilledPromise($cachedToken->getToken());
                 }
-                if ($this->cachedToken->getRefreshToken()) {
-                    $this->cachedToken = $this->refreshToken();
-                    return new FulfilledPromise($this->cachedToken->getToken());
+                if ($cachedToken->getRefreshToken()) {
+                    $cachedToken = $this->refreshToken();
+                    $this->accessTokenCache->persistAccessToken($cachedToken);
+                    return new FulfilledPromise($cachedToken->getToken());
                 }
             }
-            $this->cachedToken = $this->requestNewToken($params);
-            return new FulfilledPromise($this->cachedToken->getToken());
+            $token = $this->requestNewToken($params);
+            $this->accessTokenCache->persistAccessToken($token);
+            return new FulfilledPromise($token->getToken());
         } catch (\Exception $ex) {
             return new RejectedPromise($ex);
         }
@@ -138,7 +157,7 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
             );
         }
         $params = array_merge(
-            $this->tokenRequestContext->getRefreshTokenParams($this->cachedToken->getRefreshToken()),
+            $this->tokenRequestContext->getRefreshTokenParams($this->accessTokenCache->getAccessToken()->getRefreshToken()),
             $params
         );
         // @phpstan-ignore-next-line
@@ -172,7 +191,7 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
      */
     private function tryCAETokenRefresh(array $initialParams, string $claims): AccessToken
     {
-        if ($this->cachedToken && $this->cachedToken->getRefreshToken()) {
+        if ($this->accessTokenCache->getAccessToken() && $this->accessTokenCache->getAccessToken()->getRefreshToken()) {
             try {
                 return $this->refreshToken(['claims' => $claims]);
             } catch (\Exception $ex) {

--- a/tests/PhpLeagueAccessTokenProviderTest.php
+++ b/tests/PhpLeagueAccessTokenProviderTest.php
@@ -25,6 +25,7 @@ use Psr\Http\Message\RequestInterface;
 class PhpLeagueAccessTokenProviderTest extends TestCase
 {
     private PhpLeagueAccessTokenProvider $defaultTokenProvider;
+    private string $testJWT;
 
     protected function setUp(): void
     {
@@ -32,6 +33,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
             new ClientCredentialContext('tenantId', 'clientId', 'clientSecret'),
             ['https://graph.microsoft.com/.default']
         );
+        $this->testJWT = "headers.".base64_encode(json_encode(['sub' => '123'])).".signature";
     }
 
     public function testPassingMultipleScopes(): void
@@ -73,19 +75,19 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
         }
     }
 
-    public function testGetAuthorizationTokenCachesInMemory(): void
+    public function testGetAuthorizationTokenCachesInMemoryByDefault(): void
     {
         $oauthContexts = $this->getOauthContexts();
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'expires_in' => 5])),
                 new Response(200, [], json_encode(['access_token' => 'xyz', 'expires_in' => 5]))
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
             // Second call happens before token expires. We should get the existing access token
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
         }
     }
 
@@ -95,12 +97,13 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
         /** @var TokenRequestContext $tokenRequestContext */
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], null, $stubTokenCache = new StubAccessTokenCache());
-            $stubTokenCache->accessTokens[$tokenRequestContext->getIdentity()] = new AccessToken(['access_token' => 'persisted_token', 'expires' => time() + 5]);
+            $tokenRequestContext->setCacheKey(new AccessToken(['access_token' => $this->testJWT]));
+            $stubTokenCache->accessTokens[$tokenRequestContext->getCacheKey()] = new AccessToken(['access_token' => $this->testJWT, 'expires' => time() + 5]);
             $mockResponses = [
                 new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('persisted_token', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
         }
     }
 
@@ -111,11 +114,11 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], null, $stubTokenCache = new StubAccessTokenCache());
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'expires_in' => 5])),
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
-            $this->assertEquals('abc', $stubTokenCache->accessTokens[$tokenRequestContext->getIdentity()]->getToken());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $stubTokenCache->accessTokens[$tokenRequestContext->getCacheKey()]->getToken());
         }
     }
 
@@ -125,13 +128,13 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'expires_in' => 5])),
                 new Response(200, [], json_encode(['access_token' => 'xyz', 'expires_in' => 5]))
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://example.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://example.com')->wait());
             // Second call happens before token expires. We should get the existing access token
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
         }
     }
 
@@ -141,7 +144,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, ['https://graph.microsoft.com/.default']);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 0.1, 'refresh_token' => 'refresh'])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'expires_in' => 0.1, 'refresh_token' => 'refresh'])),
                 function (Request $request) {
                     parse_str($request->getBody()->getContents(), $requestBodyMap);
                     $this->assertArrayHasKey('refresh_token', $requestBodyMap);
@@ -150,7 +153,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
                 },
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
             sleep(1);
             // Second call happens when token has already expired
             $this->assertEquals('xyz', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
@@ -163,7 +166,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, ['https://graph.microsoft.com/.default']);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 0.1])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'expires_in' => 0.1])),
                 function (Request $request) use ($tokenRequestContext) {
                     parse_str($request->getBody()->getContents(), $requestBodyMap);
                     $expectedBody = array_merge($tokenRequestContext->getParams(), [
@@ -174,7 +177,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
                 },
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
             sleep(1);
             // Second call happens when token has already expired
             $this->assertEquals('xyz', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
@@ -216,7 +219,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
                     parse_str($request->getBody()->getContents(), $requestBodyMap);
                     $this->assertArrayHasKey('claims', $requestBodyMap);
                     $this->assertEquals(PhpLeagueAccessTokenProvider::CP1_CLAIM, $requestBodyMap['claims']);
-                    return new Response(200, [], json_encode(['access_token' => 'xyz', 'refresh_token' => 'refresh', 'expires_in' => 5]));
+                    return new Response(200, [], json_encode(['access_token' => $this->testJWT, 'refresh_token' => 'refresh', 'expires_in' => 5]));
                 },
                 function (Request $refreshTokenRequest) {
                     parse_str($refreshTokenRequest->getBody()->getContents(), $requestBodyMap);
@@ -231,7 +234,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
                 }
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('xyz', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com/users')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com/users')->wait());
             // while cached token exists, make a claims request
             $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com/users', [
                 'claims' => 'eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiY3AxIn19fQ=='
@@ -246,7 +249,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
             $context->setCAEEnabled(true);
             $tokenProvider = new PhpLeagueAccessTokenProvider($context);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'xyz', 'refresh_token' => 'refresh', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'refresh_token' => 'refresh', 'expires_in' => 5])),
                 function (Request $refreshTokenRequest) {
                     throw new Exception("Refresh token failed");
                 }
@@ -278,7 +281,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
             });
             $tokenProvider = new PhpLeagueAccessTokenProvider($context);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'xyz', 'refresh_token' => 'refresh', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'refresh_token' => 'refresh', 'expires_in' => 5])),
                 function (Request $refreshTokenRequest) {
                     throw new Exception("Refresh token failed");
                 }
@@ -307,7 +310,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
             });
             $tokenProvider = new PhpLeagueAccessTokenProvider($context);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'xyz', 'refresh_token' => 'refresh', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'refresh_token' => 'refresh', 'expires_in' => 5])),
                 function (Request $refreshTokenRequest) {
                     throw new Exception("Refresh token failed");
                 }
@@ -339,14 +342,14 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
             });
             $tokenProvider = new PhpLeagueAccessTokenProvider($context);
             $mockResponses = [
-                new Response(200, [], json_encode(['access_token' => 'abc', 'refresh_token' => 'refresh', 'expires_in' => 5])),
+                new Response(200, [], json_encode(['access_token' => $this->testJWT, 'refresh_token' => 'refresh', 'expires_in' => 5])),
                 function (Request $refreshTokenRequest) {
                     throw new Exception("Refresh token failed");
                 },
                 new Response(200, [], json_encode(['access_token' => 'xyz', 'refresh_token' => 'refresh', 'expires_in' => 5])),
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
-            $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com/users')->wait());
+            $this->assertEquals($this->testJWT, $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com/users')->wait());
             // while cached token exists, make a claims request
             $claims = 'eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiY3AxIn19fQ==';
             $this->assertEquals('xyz', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com/users', [

--- a/tests/PhpLeagueAccessTokenProviderTest.php
+++ b/tests/PhpLeagueAccessTokenProviderTest.php
@@ -92,9 +92,10 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
     public function testGetAuthorizationTokenUsesCachedToken(): void
     {
         $oauthContexts = $this->getOauthContexts();
+        /** @var TokenRequestContext $tokenRequestContext */
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], null, $stubTokenCache = new StubAccessTokenCache());
-            $stubTokenCache->accessToken = new AccessToken(['access_token' => 'persisted_token', 'expires' => time() + 5]);
+            $stubTokenCache->accessTokens[$tokenRequestContext->getIdentity()] = new AccessToken(['access_token' => 'persisted_token', 'expires' => time() + 5]);
             $mockResponses = [
                 new Response(200, [], json_encode(['access_token' => 'abc', 'expires_in' => 5])),
             ];
@@ -106,6 +107,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
     public function testNewAccessTokenIsUpdatedToTheCache(): void
     {
         $oauthContexts = $this->getOauthContexts();
+        /** @var TokenRequestContext $tokenRequestContext */
         foreach ($oauthContexts as $tokenRequestContext) {
             $tokenProvider = new PhpLeagueAccessTokenProvider($tokenRequestContext, [], [], null, $stubTokenCache = new StubAccessTokenCache());
             $mockResponses = [
@@ -113,7 +115,7 @@ class PhpLeagueAccessTokenProviderTest extends TestCase
             ];
             $tokenProvider->getOauthProvider()->setHttpClient($this->getMockHttpClient($mockResponses));
             $this->assertEquals('abc', $tokenProvider->getAuthorizationTokenAsync('https://graph.microsoft.com')->wait());
-            $this->assertEquals('abc', $stubTokenCache->accessToken->getToken());
+            $this->assertEquals('abc', $stubTokenCache->accessTokens[$tokenRequestContext->getIdentity()]->getToken());
         }
     }
 

--- a/tests/Stub/StubAccessTokenCache.php
+++ b/tests/Stub/StubAccessTokenCache.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Microsoft\Kiota\Authentication\Test\Stub;
+
+use League\OAuth2\Client\Token\AccessToken;
+use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
+
+class StubAccessTokenCache implements AccessTokenCache
+{
+    public ?AccessToken $accessToken = null;
+
+    public function getAccessToken(): ?AccessToken
+    {
+        return $this->accessToken;
+    }
+
+    public function persistAccessToken(AccessToken $accessToken): void
+    {
+        $this->accessToken = $accessToken;
+    }
+}

--- a/tests/Stub/StubAccessTokenCache.php
+++ b/tests/Stub/StubAccessTokenCache.php
@@ -7,15 +7,18 @@ use Microsoft\Kiota\Authentication\Cache\AccessTokenCache;
 
 class StubAccessTokenCache implements AccessTokenCache
 {
-    public ?AccessToken $accessToken = null;
+    /**
+     * @var array<string, AccessToken>
+     */
+    public array $accessTokens = [];
 
-    public function getAccessToken(): ?AccessToken
+    public function getAccessToken(string $identity): ?AccessToken
     {
-        return $this->accessToken;
+        return $this->accessTokens[$identity] ?? null;
     }
 
-    public function persistAccessToken(AccessToken $accessToken): void
+    public function persistAccessToken(string $identity, AccessToken $accessToken): void
     {
-        $this->accessToken = $accessToken;
+        $this->accessTokens[$identity] = $accessToken;
     }
 }


### PR DESCRIPTION
This PR:
- Abstracts token caching to an interface. Lib defaults to an in-memory cache implementation
- Caches application permission tokens using a unique key `tenantId-clientId` and delegated permission tokens using the key `tenantId-clientId-userId` where `userId` is derived from the [standard `sub` claim in JWTs](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1).  Meaning we can only cache delegated permission tokens if they're JWTs (contain the `sub` claim). Application permission tokens are always cached.
- Refactors token request context hierarchy to accommodate caching by decoupling base secret and base certificate types from the TokenRequestContext interface and uses traits instead to compose the request context types.

closes https://github.com/microsoft/kiota-authentication-phpleague-php/issues/24