### PR TITLE
Allow changing default token service URL and user info URL

### DIFF
--- a/src/Oauth/ProviderFactory.php
+++ b/src/Oauth/ProviderFactory.php
@@ -18,10 +18,11 @@ class ProviderFactory
      * https://graph.microsoft.com
      * @return GenericProvider
      */
-    public static function create(TokenRequestContext $tokenRequestContext,
-                                  array $collaborators = [],
-                                  string $tokenServiceBaseUrl = 'https://login.microsoftonline.com',
-                                  string $userInfoServiceBaseUrl = 'https://graph.microsoft.com'
+    public static function create(
+        TokenRequestContext $tokenRequestContext,
+        array $collaborators = [],
+        string $tokenServiceBaseUrl = 'https://login.microsoftonline.com',
+        string $userInfoServiceBaseUrl = 'https://graph.microsoft.com'
     ): GenericProvider
     {
         $grantFactory = new GrantFactory();

--- a/src/Oauth/ProviderFactory.php
+++ b/src/Oauth/ProviderFactory.php
@@ -2,6 +2,7 @@
 
 namespace Microsoft\Kiota\Authentication\Oauth;
 
+use InvalidArgumentException;
 use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Provider\GenericProvider;
 
@@ -11,18 +12,26 @@ class ProviderFactory
      * Initialises a PHP League provider for the Microsoft Identity platform
      * @param TokenRequestContext $tokenRequestContext
      * @param array<string, object> $collaborators
+     * @param string $tokenServiceBaseUrl Base URL for the token and authorize endpoint. Defaults to
+     * https://login.microsoftonline.com
+     * @param string $userInfoServiceBaseUrl Base URL for the user info endpoint. Defaults to
+     * https://graph.microsoft.com
      * @return GenericProvider
      */
-    public static function create(TokenRequestContext $tokenRequestContext, array $collaborators = []): GenericProvider
+    public static function create(TokenRequestContext $tokenRequestContext,
+                                  array $collaborators = [],
+                                  string $tokenServiceBaseUrl = 'https://login.microsoftonline.com',
+                                  string $userInfoServiceBaseUrl = 'https://graph.microsoft.com'
+    ): GenericProvider
     {
         $grantFactory = new GrantFactory();
         // Add our custom grant type to the registry
         $grantFactory->setGrant('urn:ietf:params:Oauth:grant-type:jwt-bearer', new OnBehalfOfGrant());
 
         return new GenericProvider([
-            'urlAccessToken' => "https://login.microsoftonline.com/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/token",
-            'urlAuthorize' => "https://login.microsoftonline.com/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/authorize",
-            'urlResourceOwnerDetails' => 'https://graph.microsoft.com/oidc/userinfo',
+            'urlAccessToken' => "$tokenServiceBaseUrl/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/token",
+            'urlAuthorize' => "$tokenServiceBaseUrl/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/authorize",
+            'urlResourceOwnerDetails' => "$userInfoServiceBaseUrl/oidc/userinfo",
             'accessTokenResourceOwnerId' => 'id_token'
         ], $collaborators + [
             'grantFactory' => $grantFactory

--- a/tests/Oauth/ProviderFactoryTest.php
+++ b/tests/Oauth/ProviderFactoryTest.php
@@ -3,13 +3,16 @@
 namespace Microsoft\Kiota\Authentication\Test\Oauth;
 
 use GuzzleHttp\Client;
+use InvalidArgumentException;
+use League\OAuth2\Client\Provider\GenericProvider;
+use League\OAuth2\Client\Token\AccessToken;
 use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
 use Microsoft\Kiota\Authentication\Oauth\ProviderFactory;
 use PHPUnit\Framework\TestCase;
 
 class ProviderFactoryTest extends TestCase
 {
-    public function testCustomHttpClient()
+    public function testCustomHttpClient(): void
     {
         $httpClient = new Client();
 
@@ -21,5 +24,33 @@ class ProviderFactoryTest extends TestCase
         );
 
         self::assertSame($httpClient, $provider->getHttpClient());
+    }
+
+    public function testDefaultConfiguration(): void
+    {
+        $oauthProvider = ProviderFactory::create(new ClientCredentialContext(
+            '1', 'client', 'secret'
+        ));
+        $this->assertInstanceOf(GenericProvider::class, $oauthProvider);
+        $this->assertEquals("https://graph.microsoft.com/oidc/userinfo", $oauthProvider->getResourceOwnerDetailsUrl(
+            $this->createMock(AccessToken::class)
+        ));
+        $this->assertEquals("https://login.microsoftonline.com/1/oauth2/v2.0/token", $oauthProvider->getBaseAccessTokenUrl([]));
+        $this->assertEquals("https://login.microsoftonline.com/1/oauth2/v2.0/authorize", $oauthProvider->getBaseAuthorizationUrl());
+    }
+
+    public function testUpdatingBaseURLs(): void
+    {
+        $chinaCloudUserInfo = 'https://microsoftgraph.chinacloudapi.cn';
+        $chinaCloudTokenService = 'https://login.chinacloudapi.cn';
+        $oauthProvider = ProviderFactory::create(new ClientCredentialContext(
+            '1', 'client', 'secret'
+        ), [], $chinaCloudTokenService, $chinaCloudUserInfo);
+        $this->assertInstanceOf(GenericProvider::class, $oauthProvider);
+        $this->assertEquals("$chinaCloudUserInfo/oidc/userinfo",$oauthProvider->getResourceOwnerDetailsUrl(
+            $this->createMock(AccessToken::class)
+        ));
+        $this->assertEquals("$chinaCloudTokenService/1/oauth2/v2.0/token", $oauthProvider->getBaseAccessTokenUrl([]));
+        $this->assertEquals("$chinaCloudTokenService/1/oauth2/v2.0/authorize", $oauthProvider->getBaseAuthorizationUrl());
     }
 }


### PR DESCRIPTION
Enables configuration of other national cloud endpoints.
part of https://github.com/microsoft/kiota-authentication-phpleague-php/issues/35