### PR TITLE
Allow setting a custom cache key

### DIFF
--- a/src/Oauth/ApplicationPermissionTrait.php
+++ b/src/Oauth/ApplicationPermissionTrait.php
@@ -10,6 +10,7 @@ namespace Microsoft\Kiota\Authentication\Oauth;
 
 
 use League\OAuth2\Client\Token\AccessToken;
+use \InvalidArgumentException;
 
 trait ApplicationPermissionTrait
 {
@@ -40,6 +41,20 @@ trait ApplicationPermissionTrait
     public function setCacheKey(?AccessToken $accessToken = null): void
     {
         $this->cacheKey = "{$this->getTenantId()}-{$this->getClientId()}";
+    }
+
+    /**
+     * Set the cache identifier for a user/application.
+     *
+     * @param string $identifier
+     * @return void
+     */
+    public function setCustomCacheKey(string $identifier): void
+    {
+        if (!$identifier) {
+            throw new InvalidArgumentException("Cache key cannot be set to an empty string");
+        }
+        $this->cacheKey = $identifier;
     }
 
     /**

--- a/src/Oauth/DelegatedPermissionTrait.php
+++ b/src/Oauth/DelegatedPermissionTrait.php
@@ -10,6 +10,7 @@ namespace Microsoft\Kiota\Authentication\Oauth;
 
 
 use League\OAuth2\Client\Token\AccessToken;
+use \InvalidArgumentException;
 
 
 trait DelegatedPermissionTrait
@@ -50,6 +51,20 @@ trait DelegatedPermissionTrait
                 }
             }
         }
+    }
+
+    /**
+     * Set the cache identifier for a user/application.
+     *
+     * @param string $identifier
+     * @return void
+     */
+    public function setCustomCacheKey(string $identifier): void
+    {
+        if (!$identifier) {
+            throw new InvalidArgumentException("Cache key cannot be set to an empty string");
+        }
+        $this->cacheKey = $identifier;
     }
 
     /**

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -28,6 +28,7 @@ use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
+use RuntimeException;
 
 /**
  * Class PhpLeagueAccessTokenProvider
@@ -255,8 +256,10 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
         if (!$this->tokenRequestContext->getCacheKey()) {
             $this->tokenRequestContext->setCacheKey($token);
         }
-        $this->accessTokenCache->persistAccessToken($this->tokenRequestContext->getCacheKey(), $token);
-        $span->addEvent(self::TOKEN_CACHE_EVENT);
+        if ($this->tokenRequestContext->getCacheKey()) {
+            $this->accessTokenCache->persistAccessToken($this->tokenRequestContext->getCacheKey(), $token);
+            $span->addEvent(self::TOKEN_CACHE_EVENT);
+        }
     }
 
     /**

--- a/src/PhpLeagueAccessTokenProvider.php
+++ b/src/PhpLeagueAccessTokenProvider.php
@@ -252,11 +252,11 @@ class PhpLeagueAccessTokenProvider implements AccessTokenProvider
      */
     private function cacheToken(AccessToken $token, SpanInterface $span): void
     {
-        $this->tokenRequestContext->setCacheKey($token);
-        if ($this->tokenRequestContext->getCacheKey()) {
-            $this->accessTokenCache->persistAccessToken($this->tokenRequestContext->getCacheKey(), $token);
-            $span->addEvent(self::TOKEN_CACHE_EVENT);
+        if (!$this->tokenRequestContext->getCacheKey()) {
+            $this->tokenRequestContext->setCacheKey($token);
         }
+        $this->accessTokenCache->persistAccessToken($this->tokenRequestContext->getCacheKey(), $token);
+        $span->addEvent(self::TOKEN_CACHE_EVENT);
     }
 
     /**


### PR DESCRIPTION
For scenarios where developers already manage token requests and caching for themselves, they could choose to pass a custom implementation of the [AccessTokenCache](https://github.com/microsoft/kiota-authentication-phpleague-php/blob/dev/src/Cache/AccessTokenCache.php), they may initialize their cache using identifiers that are relevant in their applications e.g. their application's user Ids etc. These user IDs could differ from the userID on the Graph that this lib uses, causing cache retrieval to fail.

Allowing devs to `setCustomCacheKey` on a `TokenRequestContext` allows the access token provider to check the cache using the custom key.

part of https://github.com/microsoftgraph/msgraph-sdk-php/issues/1407

