### PR TITLE
Add client options to the `ProviderFactory::create`

### DIFF
--- a/src/Oauth/ProviderFactory.php
+++ b/src/Oauth/ProviderFactory.php
@@ -12,29 +12,41 @@ class ProviderFactory
      * Initialises a PHP League provider for the Microsoft Identity platform
      * @param TokenRequestContext $tokenRequestContext
      * @param array<string, object> $collaborators
-     * @param string $tokenServiceBaseUrl Base URL for the token and authorize endpoint. Defaults to
+     * @param string|null $tokenServiceBaseUrl Base URL for the token and authorize endpoint. Defaults to
      * https://login.microsoftonline.com
-     * @param string $userInfoServiceBaseUrl Base URL for the user info endpoint. Defaults to
+     * @param string|null $userInfoServiceBaseUrl Base URL for the user info endpoint. Defaults to
      * https://graph.microsoft.com
+     * @param array<string, string> $clientOptions Additional client options to pass to the underlying http client.
      * @return GenericProvider
      */
     public static function create(
         TokenRequestContext $tokenRequestContext,
         array $collaborators = [],
-        string $tokenServiceBaseUrl = 'https://login.microsoftonline.com',
-        string $userInfoServiceBaseUrl = 'https://graph.microsoft.com'
+        ?string $tokenServiceBaseUrl = null,
+        ?string $userInfoServiceBaseUrl = null,
+        array $clientOptions = []
     ): GenericProvider
     {
+        if ($tokenServiceBaseUrl === null || empty(trim($tokenServiceBaseUrl))) {
+            $tokenServiceBaseUrl = 'https://login.microsoftonline.com';
+        }
+        if ($userInfoServiceBaseUrl === null || empty(trim($userInfoServiceBaseUrl))) {
+            $userInfoServiceBaseUrl = 'https://graph.microsoft.com';
+        }
+
         $grantFactory = new GrantFactory();
         // Add our custom grant type to the registry
         $grantFactory->setGrant('urn:ietf:params:Oauth:grant-type:jwt-bearer', new OnBehalfOfGrant());
 
-        return new GenericProvider([
-            'urlAccessToken' => "$tokenServiceBaseUrl/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/token",
-            'urlAuthorize' => "$tokenServiceBaseUrl/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/authorize",
-            'urlResourceOwnerDetails' => "$userInfoServiceBaseUrl/oidc/userinfo",
-            'accessTokenResourceOwnerId' => 'id_token'
-        ], $collaborators + [
+        $allOptions = array_merge(
+            [
+                'urlAccessToken' => "$tokenServiceBaseUrl/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/token",
+                'urlAuthorize' => "$tokenServiceBaseUrl/{$tokenRequestContext->getTenantId()}/oauth2/v2.0/authorize",
+                'urlResourceOwnerDetails' => "$userInfoServiceBaseUrl/oidc/userinfo",
+                'accessTokenResourceOwnerId' => 'id_token'
+            ], $clientOptions
+        );
+        return new GenericProvider($allOptions, $collaborators + [
             'grantFactory' => $grantFactory
         ]);
     }


### PR DESCRIPTION
This PR
- Allows passing of client options to create factory method so users can easily use their custom client options i.e `proxy` and `verify` or just `proxy`.
- Makes the `$tokenServiceBaseUrl` and `$userInfoServiceBaseUrl ` optional and nullable so users can pass null if they want to keep the default value of microsoft graph or override it.

Related issue https://github.com/microsoftgraph/msgraph-sdk-php/issues/1483