### PR TITLE
Fix caching access tokens for delegated permissions

### DIFF
--- a/src/Oauth/ApplicationPermissionTrait.php
+++ b/src/Oauth/ApplicationPermissionTrait.php
@@ -32,7 +32,7 @@ trait ApplicationPermissionTrait
 
     /**
      * Set the identity of the user/application. This is used as the unique cache key
-     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For delegated permissions the key is {tenantId}-{clientId}-{accessTokenHash}
      * For application permissions, they key is {tenantId}-{clientId}
      * @param AccessToken|null $accessToken
      * @return void
@@ -44,7 +44,7 @@ trait ApplicationPermissionTrait
 
     /**
      * Return the identity of the user/application. This is used as the unique cache key
-     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For delegated permissions the key is {tenantId}-{clientId}-{accessTokenHash}
      * For application permissions, they key is {tenantId}-{clientId}
      * @return string|null
      */

--- a/src/Oauth/TokenRequestContext.php
+++ b/src/Oauth/TokenRequestContext.php
@@ -48,7 +48,7 @@ interface TokenRequestContext
 
     /**
      * Set the identity of the user/application. This is used as the unique cache key
-     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For delegated permissions the key is {tenantId}-{clientId}-{accessTokenHash}
      * For application permissions, they key is {tenantId}-{clientId}
      * @param AccessToken|null $accessToken
      * @return void
@@ -57,7 +57,7 @@ interface TokenRequestContext
 
     /**
      * Return the identity of the user/application. This is used as the unique cache key
-     * For delegated permissions the key is {tenantId}-{clientId}-{userId}
+     * For delegated permissions the key is {tenantId}-{clientId}-{accessTokenHash}
      * For application permissions, they key is {tenantId}-{clientId}
      *
      * @return string|null

--- a/tests/Cache/InMemoryAccessTokenCacheTest.php
+++ b/tests/Cache/InMemoryAccessTokenCacheTest.php
@@ -4,6 +4,7 @@ namespace Microsoft\Kiota\Authentication\Test\Cache;
 
 use League\OAuth2\Client\Token\AccessToken;
 use Microsoft\Kiota\Authentication\Cache\InMemoryAccessTokenCache;
+use Microsoft\Kiota\Authentication\Oauth\AuthorizationCodeContext;
 use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
 use Microsoft\Kiota\Authentication\Oauth\TokenRequestContext;
 use PHPUnit\Framework\TestCase;
@@ -57,5 +58,16 @@ class InMemoryAccessTokenCacheTest extends TestCase
 
         $this->assertInstanceOf(AccessToken::class, $cache->getTokenWithContext($this->testTokenRequestContext));
         $this->assertInstanceOf(AccessToken::class, $cache->getTokenWithContext($secondContext));
+    }
+
+    public function testCacheKeyIsSetForNonJWTToken() {
+        $accessToken = $this->createMock(AccessToken::class);
+        $accessToken->method('getToken')->willReturn('token');
+
+        $cache = new InMemoryAccessTokenCache();
+        $delegatedTokenRequestContext = new AuthorizationCodeContext("tenantId", "clientId", "clientSecret", "redirectUri", "code");
+        $cache->withToken($delegatedTokenRequestContext, $accessToken);
+
+        $this->assertNotEmpty($delegatedTokenRequestContext->getCacheKey());
     }
 }


### PR DESCRIPTION
### Context
When caching tokens, we need to ensure that during retrieval, we only retrieve the access token for the intended user (if delegated auth had been used) or for the intended application (if app permissions were used)

We previously used unique cache keys to uniquely identify a user/app from the cache:
app permissions: `{tenantId}-{clientId}`
delegated permissions: `{tenantId}-{clientId}-{userId}`

### This PR
Changes from exploding the access token to retrieve the subject claim value to using a hash of the access token string as the cache key for delegated permissions.

It is not [recommended ](https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens#validate-tokens) to inspect access tokens since they may not always be JWTs. It's recommended to request & use [ID tokens](https://learn.microsoft.com/en-us/entra/identity-platform/id-tokens) instead.

We opted to generate a hash of the access token instead of the ID token since ID tokens are not activated [out of the box](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#enable-id-tokens) for all apps.


closes https://github.com/microsoftgraph/msgraph-sdk-php/issues/1407
closes https://github.com/microsoft/kiota-authentication-phpleague-php/issues/92