### PR TITLE
Make cache keys reproducible and auth code string optional

### DIFF
--- a/src/Oauth/AuthorizationCodeContext.php
+++ b/src/Oauth/AuthorizationCodeContext.php
@@ -47,7 +47,7 @@ class AuthorizationCodeContext extends BaseSecretContext implements TokenRequest
      */
     public function __construct(string $tenantId, string $clientId, string $clientSecret, string $authCode, string $redirectUri, array $additionalParams = [])
     {
-        if (!$authCode || !$redirectUri) {
+        if (!$redirectUri) {
             throw new InvalidArgumentException('$authCode or $redirectUri cannot be empty.');
         }
         $this->authCode = $authCode;

--- a/src/Oauth/DelegatedPermissionTrait.php
+++ b/src/Oauth/DelegatedPermissionTrait.php
@@ -40,7 +40,7 @@ trait DelegatedPermissionTrait
     public function setCacheKey(?AccessToken $accessToken = null): void
     {
         if ($accessToken && $accessToken->getToken()) {
-            $uniqueIdentifier = md5($accessToken->getToken());
+            $uniqueIdentifier = hash("sha256", $accessToken->getToken());
             $this->cacheKey = "{$this->getTenantId()}-{$this->getClientId()}-{$uniqueIdentifier}";
         }
     }

--- a/src/Oauth/DelegatedPermissionTrait.php
+++ b/src/Oauth/DelegatedPermissionTrait.php
@@ -40,7 +40,7 @@ trait DelegatedPermissionTrait
     public function setCacheKey(?AccessToken $accessToken = null): void
     {
         if ($accessToken && $accessToken->getToken()) {
-            $uniqueIdentifier = password_hash($accessToken->getToken(), PASSWORD_DEFAULT);
+            $uniqueIdentifier = md5($accessToken->getToken());
             $this->cacheKey = "{$this->getTenantId()}-{$this->getClientId()}-{$uniqueIdentifier}";
         }
     }

--- a/tests/Cache/InMemoryAccessTokenCacheTest.php
+++ b/tests/Cache/InMemoryAccessTokenCacheTest.php
@@ -77,7 +77,7 @@ class InMemoryAccessTokenCacheTest extends TestCase
 
         $delegatedTokenRequestContext = new AuthorizationCodeContext("tenantId", "clientId", "clientSecret", "redirectUri", "code");
         $delegatedTokenRequestContext->setCacheKey($accessToken);
-        $this->assertEquals("tenantId-clientId-".md5('token'), $delegatedTokenRequestContext->getCacheKey());
+        $this->assertEquals("tenantId-clientId-".hash("sha256", 'token'), $delegatedTokenRequestContext->getCacheKey());
         $cache = new InMemoryAccessTokenCache($delegatedTokenRequestContext, $accessToken);
 
         // initialise another cache with same token & ensure token key is still the same for user

--- a/tests/Cache/InMemoryAccessTokenCacheTest.php
+++ b/tests/Cache/InMemoryAccessTokenCacheTest.php
@@ -70,4 +70,20 @@ class InMemoryAccessTokenCacheTest extends TestCase
 
         $this->assertNotEmpty($delegatedTokenRequestContext->getCacheKey());
     }
+
+    public function testCacheKeyForDelegatedPermissionsIsReproducible() {
+        $accessToken = $this->createMock(AccessToken::class);
+        $accessToken->method('getToken')->willReturn('token');
+
+        $delegatedTokenRequestContext = new AuthorizationCodeContext("tenantId", "clientId", "clientSecret", "redirectUri", "code");
+        $delegatedTokenRequestContext->setCacheKey($accessToken);
+        $this->assertEquals("tenantId-clientId-".md5('token'), $delegatedTokenRequestContext->getCacheKey());
+        $cache = new InMemoryAccessTokenCache($delegatedTokenRequestContext, $accessToken);
+
+        // initialise another cache with same token & ensure token key is still the same for user
+        $newTokenContext = new AuthorizationCodeContext("tenantId", "clientId", "clientSecret", "redirectUri", "code");
+        $newCache = new InMemoryAccessTokenCache($newTokenContext, $accessToken);
+        $this->assertEquals($delegatedTokenRequestContext->getCacheKey(), $newTokenContext->getCacheKey());
+        $this->assertEquals($cache->getAccessToken($delegatedTokenRequestContext->getCacheKey()), $newCache->getAccessToken($newTokenContext->getCacheKey()));
+    }
 }


### PR DESCRIPTION
Changes hashing of the access token to create  a cache-key to a reproducible algorithm. `password_hash` uses the bcrypt algorithm with its own built-in random salt making consecutive runs for the same token string produce different hashes.

Streamlining this to a reproducible algorithm reduces complexity and makes the in memory cache easier to extend due to better consistency.

context: https://github.com/microsoft/kiota-authentication-phpleague-php/pull/98